### PR TITLE
Update utils.py

### DIFF
--- a/pdfindex/utils.py
+++ b/pdfindex/utils.py
@@ -5,7 +5,7 @@ import collections
 
 def flatten(l):
     for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, str):
+        if isinstance(el, collections.abc.Iterable) and not isinstance(el, str):
             for sub in flatten(el):
                 yield sub
         else:


### PR DESCRIPTION
Change collections.Iterable to collections.abc.Iterable to make it compatible with newer Python versions.

As stated in https://docs.python.org/3/library/collections.abc.html: New in version 3.3: Formerly, this module was part of the collections module.